### PR TITLE
Update system requirements to knowledge base to v1203 and fix a typo

### DIFF
--- a/v1203/admin/installation_roadmap.md
+++ b/v1203/admin/installation_roadmap.md
@@ -17,7 +17,7 @@ Table 1. Where to find more information
 
 |Item|More information|
 |----|----------------|
-|System requirements|[HCL Sametime® System Requirements](https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0108387)|
+|System requirements|[HCL Sametime® System Requirements](https://support.hcl-software.com/csm?id=kb_article&sysparm_article=KB0121489)|
 |Planning|-   [Planning the network topology and connectivity](topology.md)|
 |        |-   [Sametime client preferences](config_client_pref_tables.md)|
 |        |-   [Sametime client configuration options](sametime_client_configuration.md)|

--- a/v1203/admin/system_requirements.md
+++ b/v1203/admin/system_requirements.md
@@ -8,5 +8,5 @@ The graphic below shows a simple topology with the required components: MongoDB 
 
 ![Simple Sametime topology ](Images/topology_simple.png)
 
-**Parent Topic:  **[Prerequistes](c_planning_prereqs.md)
+**Parent Topic:  **[prerequisites](c_planning_prereqs.md)
 


### PR DESCRIPTION
This PR updates the knowledge base link for the system requirements from the old v1202 to v1203. A typo is also fixed ("prerequisites").
